### PR TITLE
Fix index out of bounds exception with multiple array ops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>fi.vm.sade</groupId>
     <artifactId>auditlogger</artifactId>
     <packaging>jar</packaging>
-    <version>9.2.2-SNAPSHOT</version>
+    <version>9.2.3-SNAPSHOT</version>
     <name>auditlogger</name>
 
     <properties>

--- a/src/main/java/fi/vm/sade/auditlog/Changes.java
+++ b/src/main/java/fi/vm/sade/auditlog/Changes.java
@@ -178,6 +178,7 @@ public final class Changes {
         }
         private Builder jsonDiffToChanges(JsonElement beforeJson, JsonElement afterJson) {
             JsonPatch patchArray = jsonPatchFactory.create(beforeJson, afterJson);
+            JsonElement current = beforeJson;
             for (Iterator<AbsOperation> it = patchArray.iterator(); it.hasNext(); ) {
                 AbsOperation absOperation = it.next();
                 String operation = absOperation.getOperationName();
@@ -190,19 +191,19 @@ public final class Changes {
                         break;
                     }
                     case "remove": {
-                        JsonElement oldValue = Util.getJsonElementByPath(beforeJson, prettyPath);
+                        JsonElement oldValue = Util.getJsonElementByPath(current, prettyPath);
                         removed(prettyPath, toJsonString(oldValue));
                         break;
                     }
                     case "replace": {
-                        JsonElement oldValue = Util.getJsonElementByPath(beforeJson, prettyPath);
+                        JsonElement oldValue = Util.getJsonElementByPath(current, prettyPath);
                         JsonElement newValue = ((ReplaceOperation) absOperation).data;
                         updated(prettyPath, toJsonString(oldValue), toJsonString(newValue));
                         break;
                     }
                     case "move": {
                         String prettyFromPath = prettify(((MoveOperation) absOperation).from);
-                        JsonElement oldValue = Util.getJsonElementByPath(beforeJson, prettyFromPath);
+                        JsonElement oldValue = Util.getJsonElementByPath(current, prettyFromPath);
                         removed(prettyFromPath, toJsonString(oldValue));
 
                         JsonElement newValue = Util.getJsonElementByPath(afterJson, prettyPath);
@@ -212,6 +213,7 @@ public final class Changes {
                     default: throw new IllegalArgumentException(String.format("Unknown operation %s in %s . before: %s . after: %s"
                             , operation, absOperation.path, beforeJson, afterJson));
                 }
+                current = absOperation.apply(current);
             }
             return this;
         }


### PR DESCRIPTION
Otettu vain suora korjaus IndexOutOfBoundsExceptioniin PR:stä #23. 

Jätetään muut muutokset vielä pöydälle, koska niihin uppoaisi helposti paljon aikaa.
Projektin käyttämä kirjasto json-patchin muodostamiseksi vaikuttaa kehnolaatuiselta ja kirjaston tuottamat patchit (etenkin päivitykset arrayn sisälle) eivät useinkaan vaikuta vastaavan todellisuutta; muodostetun json-patchin muokkaamisen sijaan (kuten PR:ssä #23 on yritetty) oikea ratkaisu olisi käyttää jotain parempilaatuista kirjastoa.