### PR TITLE
fix upgrade gson from 2.10.1 to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>fi.vm.sade</groupId>
     <artifactId>auditlogger</artifactId>
     <packaging>jar</packaging>
-    <version>9.2.5-SNAPSHOT</version>
+    <version>9.2.6-SNAPSHOT</version>
     <name>auditlogger</name>
 
     <properties>


### PR DESCRIPTION
- ~Bump gson from 2.10.1 to 2.12.0~
- Bump auditlogger version
